### PR TITLE
URL Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: erlang
 notifications:
-  webhooks: http://basho-engbot.herokuapp.com/travis?key=66724b424957d598311ba00bb2d137fcae4eae21
+  webhooks: https://basho-engbot.herokuapp.com/travis?key=66724b424957d598311ba00bb2d137fcae4eae21
   email: eng@basho.com
 otp_release:
   - R15B01

--- a/README.org
+++ b/README.org
@@ -1,14 +1,14 @@
 * webmachine
 ** Overview
 
-[[http://travis-ci.org/basho/webmachine][Travis-CI]] :: [[https://secure.travis-ci.org/basho/webmachine.png]]
+[[https://travis-ci.org/basho/webmachine][Travis-CI]] :: [[https://secure.travis-ci.org/basho/webmachine.png]]
 
 Webmachine is an application layer that adds HTTP semantic awareness
 on top of the excellent bit-pushing and HTTP syntax-management
 provided by mochiweb, and provides a simple and clean way to connect
 that to your application's behavior.
 
-More information is available [[http://webmachine.basho.com/][here]].
+More information is available [[https://webmachine.basho.com/][here]].
 
 ** Quick Start
 A shell script is provided in the =webmachine= repository to help
@@ -37,7 +37,7 @@ make
 
 The application will be available at [[http://localhost:8000]].
 
-To learn more continue reading [[http://webmachine.basho.com/][here]].
+To learn more continue reading [[https://webmachine.basho.com/][here]].
 
 ** Contributing
    We encourage contributions to =webmachine= from the community.

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -30,7 +30,7 @@
 %%                wrq:reqdata()) ->
 %%                                            dispterm() | dispfail()
 %% @doc Interface for URL dispatching.
-%% See also http://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
+%% See also https://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
 dispatch(PathAsString, DispatchList, RD) ->
     dispatch([], PathAsString, DispatchList, RD).
 
@@ -38,7 +38,7 @@ dispatch(PathAsString, DispatchList, RD) ->
 %%                DispatchList::[matchterm()], wrq:reqdata()) ->
 %%         dispterm() | dispfail()
 %% @doc Interface for URL dispatching.
-%% See also http://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
+%% See also https://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
 dispatch(HostAsString, PathAsString, DispatchList, RD) ->
     Path = string:tokens(PathAsString, [?SEPARATOR]),
     % URIs that end with a trailing slash are implicitly one token

--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -73,7 +73,7 @@
 %% @spec add_route(hostmatchterm() | pathmatchterm()) -> ok
 %% @doc Adds a route to webmachine's route table. The route should
 %%      be the format documented here:
-%% http://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
+%% https://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
 add_route(Route) ->
     add_route(default, Route).
 

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -372,7 +372,7 @@ unescape_quoted_string([Char | Rest], Acc) ->
 
 %% This is faster than timer:now_diff() because it does not use bignums.
 %% But it returns *milliseconds*  (timer:now_diff returns microseconds.)
-%% From http://www.erlang.org/ml-archive/erlang-questions/200205/msg00027.html
+%% From https://www.erlang.org/ml-archive/erlang-questions/200205/msg00027.html
 
 %% @doc  Compute the difference between two now() tuples, in milliseconds.
 %% @spec now_diff_milliseconds(now(), now()) -> integer()

--- a/src/wmtrace_resource.erl
+++ b/src/wmtrace_resource.erl
@@ -32,7 +32,7 @@
 %% @spec add_dispatch_rule(string(), string()) -> ok
 %% @doc Add a dispatch rule to point at wmtrace_resource.
 %%      Example: to serve wmtrace_resource from
-%%        http://yourhost/dev/wmtrace/
+%%        https://yourhost/dev/wmtrace/
 %%               with trace files on disk at
 %%        priv/traces
 %%               call:
@@ -329,7 +329,7 @@ encode_trace_io(Data) ->
 ?TAG(button).
 
 html(_Attrs, Content) ->
-    [<<"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">">>,
+    [<<"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">">>,
      <<"<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">">>,
      Content,
      <<"</html>">>].

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -322,7 +322,7 @@ base_uri_test_() ->
                                    StringPath,
                                    R1)
         end,
-    Tests = [{{http, "somewhere.com:8080"}, "http://somewhere.com:8080"},
+    Tests = [{{http, "somewhere.com:8080"}, "https://somewhere.com:8080"},
              {{https, "somewhere.com:8080"}, "https://somewhere.com:8080"},
 
              {{http, "somewhere.com"}, "http://somewhere.com"},
@@ -331,7 +331,7 @@ base_uri_test_() ->
              {{http, "somewhere.com:80"}, "http://somewhere.com"},
              {{https, "somewhere.com:443"}, "https://somewhere.com"},
              {{https, "somewhere.com:80"}, "https://somewhere.com:80"},
-             {{http, "somewhere.com:443"}, "http://somewhere.com:443"}],
+             {{http, "somewhere.com:443"}, "https://somewhere.com:443"}],
     [ ?_assertEqual(Expect, base_uri(Make_req(Scheme, Host)))
       || {{Scheme, Host}, Expect} <- Tests ].
 

--- a/www/blogs.html
+++ b/www/blogs.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -26,7 +26,7 @@ In addition to the documentation on this site and the source code on bitbucket, 
 The <a href="http://blog.therestfulway.com/">restful way</a> blog is almost entirely dedicated to Webmachine.
 </p>
 <p>
-The <a href="http://blog.beerriot.com/">BeerRiot blog</a> contains multiple topics, including a wealth of examples and discussion of Webmachine.
+The <a href="https://blog.beerriot.com/">BeerRiot blog</a> contains multiple topics, including a wealth of examples and discussion of Webmachine.
 </p>
 <p>
 The blog of <a href="http://blog.argv0.net/">Andy Gross</a> has some
@@ -34,16 +34,16 @@ useful hints and tutorials.
 </p>
 <p>
 Paul Mineiro posted about
-<a href="http://dukesoferl.blogspot.com/2009/08/dynamically-loading-webmachine.html">dynamically loading webmachine resources</a>.
+<a href="https://dukesoferl.blogspot.com/2009/08/dynamically-loading-webmachine.html">dynamically loading webmachine resources</a>.
 </p>
 <p>
-<a href="http://weblog.hypotheticalabs.com/?page_id=413">Kevin Smith</a>
+<a href="https://weblog.hypotheticalabs.com/?page_id=413">Kevin Smith</a>
 teaches an excellent Erlang training class which often culminates with
 development of applications in Webmachine.
 </p>
 <p>
 There is a fairly low traffic
-<a href="http://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com">mailing list</a>
+<a href="https://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com">mailing list</a>
 for technical discussion of Webmachine.
 </p>
 		</div>
@@ -53,7 +53,7 @@ for technical discussion of Webmachine.
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/contact.html
+++ b/www/contact.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -24,7 +24,7 @@ Have questions about Webmachine that aren't answered here? We'd love
 to hear from you.
 </p>
 <p>
-Subscribers to the <a href="http://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com">Webmachine mailing list</a> include both users and the core development team.
+Subscribers to the <a href="https://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com">Webmachine mailing list</a> include both users and the core development team.
 </p>
 
 		</div>
@@ -34,7 +34,7 @@ Subscribers to the <a href="http://lists.therestfulway.com/mailman/listinfo/webm
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/debugging.html
+++ b/www/debugging.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -49,7 +49,7 @@ wmtrace_resource:add_dispatch_rule("wmtrace", "/tmp").
 
 <p>
 Now issue the HTTP request that you're trying to debug.  Once it has
-finished, point your browser at <code>http://YOUR_HOST/wmtrace/</code>.
+finished, point your browser at <code>https://YOUR_HOST/wmtrace/</code>.
 You'll see one or more trace files available for inspection.
 Click on one of them to navigate to the trace inspection utility,
 which will look something like this:
@@ -179,7 +179,7 @@ and <code>wmtrace_resource:remove_dispatch_rules/0</code>.
 <p>
 Call <code>add_dispatch_rule/2</code> with the HTTP-exported path, and
 the path to the trace files.  For example, to expose the viewer at
-<code>http://YOUR_HOST/dev/wmtrace/</code> and point it at the trace
+<code>https://YOUR_HOST/dev/wmtrace/</code> and point it at the trace
 files in <code>/tmp/traces</code>, type in your application's erlang
 shell:
 </p>
@@ -278,7 +278,7 @@ Pids are simply logged in a marked tuple, after being run through
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/diagram.html
+++ b/www/diagram.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -43,7 +43,7 @@ A copy of v3 is found in the webmachine source tree for convenience.
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/dispatcher.html
+++ b/www/dispatcher.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -107,7 +107,7 @@ The examples below are taken from
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/docs.html
+++ b/www/docs.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -32,7 +32,7 @@ Webmachine.  A few of your options are:
  <li><a href="resources.html">learn about the functions that can make up a resource</a></li>
  <li><a href="reqdata.html">see how your resource can access the HTTP Request</a></li>
  <li><a href="http://blog.therestfulway.com/2009/05/video-slideshow-introducing-webmachine.html">watch a video</a></li>
- <li><a href="http://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com">join the mailing list</a></li>
+ <li><a href="https://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com">join the mailing list</a></li>
  <li><a href="debugging.html">debug your application </a></li>
  <li><a href="blogs.html">check out some blogs </a></li>
 </ul>
@@ -44,7 +44,7 @@ Webmachine.  A few of your options are:
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/example_resources.html
+++ b/www/example_resources.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -26,12 +26,12 @@ The simplest possible example is the one produced via the
 <p>
 For an example of a read/write filesystem server showing several
 interesting features and supporting GET, PUT, DELETE, and POST, see
-<a href="http://bitbucket.org/justin/webmachine/src/tip/demo/src/demo_fs_resource.erl">demo_fs_resource</a>.
+<a href="https://bitbucket.org/justin/webmachine/src/tip/demo/src/demo_fs_resource.erl">demo_fs_resource</a>.
 </p>
 <p>
 For a very simple resource demonstrating content negotiation, basic
 auth, and some caching headers, see
-<a href="http://bitbucket.org/justin/webmachine/src/tip/demo/src/webmachine_demo_resource.erl">webmachine_demo_resource</a>.
+<a href="https://bitbucket.org/justin/webmachine/src/tip/demo/src/webmachine_demo_resource.erl">webmachine_demo_resource</a>.
 </p>
 <p>
 Some example code based on webmachine_demo_resource follows.
@@ -236,7 +236,7 @@ of this page.
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/index.html
+++ b/www/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a class="current" href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		
@@ -23,7 +23,7 @@
 		<div id="left">
 <p>
 Webmachine is an application layer that adds HTTP semantic awareness on top of the excellent bit-pushing and HTTP syntax-management provided by
-<a href="http://code.google.com/p/mochiweb/">mochiweb</a>,
+<a href="https://code.google.com/p/mochiweb/">mochiweb</a>,
 and provides a simple and clean way to connect that to your
 application's behavior.
 </p>
@@ -52,7 +52,7 @@ and REST, we help them to write and extend Web applications quickly while not di
 				<li><a href="blogs.html">other writing</a></li>
 			</ul>
                         <a href="diagram.html"><img src="images/WM200-crop.png" alt="Webmachine Diagram" /></a>
-                        <a href="http://www.basho.com"><img src="images/basho-landscape.gif" alt="Basho" /></a>
+                        <a href="https://riak.com/"><img src="images/basho-landscape.gif" alt="Basho" /></a>
 		</div>
 		<div id="footer">
 
@@ -60,7 +60,7 @@ and REST, we help them to write and extend Web applications quickly while not di
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/intros.html
+++ b/www/intros.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -28,7 +28,7 @@ If you would prefer to watch a narrated slideshow introduction, this is roughly 
 <a href="http://www.erlang-factory.com/conference/SFBayAreaErlangFactory2009">Bay Area Erlang Factory 2009</a>:
 </p>
 
-<object width="512" height="322"><param name="movie" value="http://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.40" /><param name="allowFullScreen" value="true" /><param name="AllowScriptAccess" VALUE="always" /><param name="bgcolor" value="#000000" /><param name="flashVars" value="id=13693397&vid=5178506&lang=en-us&intl=us&thumbUrl=http%3A//l.yimg.com/a/p/i/bcst/videosearch/9129/86376656.jpeg&embed=1" /><embed src="http://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.40" type="application/x-shockwave-flash" width="512" height="322" allowFullScreen="true" AllowScriptAccess="always" bgcolor="#000000" flashVars="id=13693397&vid=5178506&lang=en-us&intl=us&thumbUrl=http%3A//l.yimg.com/a/p/i/bcst/videosearch/9129/86376656.jpeg&embed=1" ></embed></object>
+<object width="512" height="322"><param name="movie" value="https://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.40" /><param name="allowFullScreen" value="true" /><param name="AllowScriptAccess" VALUE="always" /><param name="bgcolor" value="#000000" /><param name="flashVars" value="id=13693397&vid=5178506&lang=en-us&intl=us&thumbUrl=http%3A//l.yimg.com/a/p/i/bcst/videosearch/9129/86376656.jpeg&embed=1" /><embed src="https://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.40" type="application/x-shockwave-flash" width="512" height="322" allowFullScreen="true" AllowScriptAccess="always" bgcolor="#000000" flashVars="id=13693397&vid=5178506&lang=en-us&intl=us&thumbUrl=http%3A//l.yimg.com/a/p/i/bcst/videosearch/9129/86376656.jpeg&embed=1" ></embed></object>
 
 <p>
 Some <a href="blogs.html">blogs</a> also have posts that can serve as
@@ -48,7 +48,7 @@ read <a href="docs.html">more documentation</a> once you get up and running.
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/mechanics.html
+++ b/www/mechanics.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -94,7 +94,7 @@ application's Web behavior simply by filling in the other
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/quickstart.html
+++ b/www/quickstart.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -25,7 +25,7 @@
 <p>Get the webmachine code:</p>
 
 <p><pre>
-hg clone http://bitbucket.org/justin/webmachine/ webmachine-read-only
+hg clone https://bitbucket.org/justin/webmachine/ webmachine-read-only
 </pre></p>
 
 <p>Build webmachine:</p>
@@ -63,7 +63,7 @@ at /tmp/mywebdemo/src/mywebdemo_resource.erl.</p>
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/reftrans.html
+++ b/www/reftrans.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -38,7 +38,7 @@ Note that there is one important exception to this.  The <a href="streambody.htm
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/reqdata.html
+++ b/www/reqdata.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -129,7 +129,7 @@ A couple of nonstandard types are assumed here:
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/resources.html
+++ b/www/resources.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -128,7 +128,7 @@ The above are all of the supported predefined resource functions. In addition to
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/www/streambody.html
+++ b/www/streambody.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="author" content="Basho Technologies" />
@@ -13,7 +13,7 @@
 		<h1><span class="hr"></span><a href="/">webmachine</a></h1>
 		<ul id="top">
 			<li><a href="/">Home</a></li>
-			<li><a href="http://bitbucket.org/justin/webmachine/">Source Code</a></li>
+			<li><a href="https://bitbucket.org/justin/webmachine/">Source Code</a></li>
                         <li><a href="contact.html">Contact</a></li>
 		</ul>
 		<div id="left">
@@ -162,7 +162,7 @@ real-world use of streaming request/response bodies.
 	</div>
 
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://blog.argv0.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://blog.argv0.net/) result AnnotatedConnectException).
* http://blog.therestfulway.com/ (200) with 1 occurrences could not be migrated:  
   ([https](https://blog.therestfulway.com/) result ClosedChannelException).
* http://blog.therestfulway.com/2009/05/video-slideshow-introducing-webmachine.html (200) with 1 occurrences could not be migrated:  
   ([https](https://blog.therestfulway.com/2009/05/video-slideshow-introducing-webmachine.html) result ClosedChannelException).
* http://www.erlang-factory.com/conference/SFBayAreaErlangFactory2009 (200) with 1 occurrences could not be migrated:  
   ([https](https://www.erlang-factory.com/conference/SFBayAreaErlangFactory2009) result SSLHandshakeException).
* http://www.erlang-factory.com/conference/SFBayAreaErlangFactory2009/speakers/justinsheehy (200) with 1 occurrences could not be migrated:  
   ([https](https://www.erlang-factory.com/conference/SFBayAreaErlangFactory2009/speakers/justinsheehy) result SSLHandshakeException).
* http://somewhere.com (403) with 2 occurrences could not be migrated:  
   ([https](https://somewhere.com) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.basho.com (301) with 1 occurrences migrated to:  
  https://riak.com/ ([https](https://www.basho.com) result SSLHandshakeException).
* http://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com (ConnectTimeoutException) with 3 occurrences migrated to:  
  https://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com ([https](https://lists.therestfulway.com/mailman/listinfo/webmachine_lists.therestfulway.com) result ConnectTimeoutException).
* http://somewhere.com:443 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://somewhere.com:443 ([https](https://somewhere.com:443) result ConnectTimeoutException).
* http://somewhere.com:8080 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://somewhere.com:8080 ([https](https://somewhere.com:8080) result ConnectTimeoutException).
* http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd (ReadTimeoutException) with 15 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd) result ReadTimeoutException).
* http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* http://YOUR_HOST/dev/wmtrace/ (UnknownHostException) with 1 occurrences migrated to:  
  https://YOUR_HOST/dev/wmtrace/ ([https](https://YOUR_HOST/dev/wmtrace/) result UnknownHostException).
* http://YOUR_HOST/wmtrace/ (UnknownHostException) with 1 occurrences migrated to:  
  https://YOUR_HOST/wmtrace/ ([https](https://YOUR_HOST/wmtrace/) result UnknownHostException).
* http://weblog.hypotheticalabs.com/?page_id=413 (UnknownHostException) with 1 occurrences migrated to:  
  https://weblog.hypotheticalabs.com/?page_id=413 ([https](https://weblog.hypotheticalabs.com/?page_id=413) result UnknownHostException).
* http://webmachine.basho.com/ (UnknownHostException) with 2 occurrences migrated to:  
  https://webmachine.basho.com/ ([https](https://webmachine.basho.com/) result UnknownHostException).
* http://www (UnknownHostException) with 15 occurrences migrated to:  
  https://www ([https](https://www) result UnknownHostException).
* http://yourhost/dev/wmtrace/ (UnknownHostException) with 1 occurrences migrated to:  
  https://yourhost/dev/wmtrace/ ([https](https://yourhost/dev/wmtrace/) result UnknownHostException).
* http://basho-engbot.herokuapp.com/travis?key=66724b424957d598311ba00bb2d137fcae4eae21 (404) with 1 occurrences migrated to:  
  https://basho-engbot.herokuapp.com/travis?key=66724b424957d598311ba00bb2d137fcae4eae21 ([https](https://basho-engbot.herokuapp.com/travis?key=66724b424957d598311ba00bb2d137fcae4eae21) result 404).
* http://bitbucket.org/justin/webmachine/src/tip/demo/src/demo_fs_resource.erl (301) with 1 occurrences migrated to:  
  https://bitbucket.org/justin/webmachine/src/tip/demo/src/demo_fs_resource.erl ([https](https://bitbucket.org/justin/webmachine/src/tip/demo/src/demo_fs_resource.erl) result 404).
* http://bitbucket.org/justin/webmachine/src/tip/demo/src/webmachine_demo_resource.erl (301) with 1 occurrences migrated to:  
  https://bitbucket.org/justin/webmachine/src/tip/demo/src/webmachine_demo_resource.erl ([https](https://bitbucket.org/justin/webmachine/src/tip/demo/src/webmachine_demo_resource.erl) result 404).
* http://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.40 (404) with 2 occurrences migrated to:  
  https://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.40 ([https](https://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.40) result 404).
* http://www.erlang.org/ml-archive/erlang-questions/200205/msg00027.html (404) with 1 occurrences migrated to:  
  https://www.erlang.org/ml-archive/erlang-questions/200205/msg00027.html ([https](https://www.erlang.org/ml-archive/erlang-questions/200205/msg00027.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration with 3 occurrences migrated to:  
  https://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration ([https](https://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration) result 200).
* http://blog.beerriot.com/ with 1 occurrences migrated to:  
  https://blog.beerriot.com/ ([https](https://blog.beerriot.com/) result 200).
* http://dukesoferl.blogspot.com/2009/08/dynamically-loading-webmachine.html with 1 occurrences migrated to:  
  https://dukesoferl.blogspot.com/2009/08/dynamically-loading-webmachine.html ([https](https://dukesoferl.blogspot.com/2009/08/dynamically-loading-webmachine.html) result 200).
* http://travis-ci.org/basho/webmachine with 1 occurrences migrated to:  
  https://travis-ci.org/basho/webmachine ([https](https://travis-ci.org/basho/webmachine) result 200).
* http://code.google.com/p/mochiweb/ with 1 occurrences migrated to:  
  https://code.google.com/p/mochiweb/ ([https](https://code.google.com/p/mochiweb/) result 301).
* http://bitbucket.org/justin/webmachine/ with 16 occurrences migrated to:  
  https://bitbucket.org/justin/webmachine/ ([https](https://bitbucket.org/justin/webmachine/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1:80/a/b/c/d/e with 1 occurrences
* http://127.0.0.1:8000/ with 1 occurrences
* http://localhost:12000/etagtest/foo with 1 occurrences
* http://localhost:8000 with 1 occurrences
* http://localhost:8000/ with 2 occurrences
* http://localhost:8000/demo with 1 occurrences
* http://localhost:8000/demo/authdemo with 3 occurrences
* http://localhost:8000/fs/demo.txt with 1 occurrences
* http://www.w3.org/1999/xhtml with 16 occurrences