### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/src/webmachine.erl
+++ b/src/webmachine.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_app.erl
+++ b/src/webmachine_app.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -7,7 +7,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_deps.erl
+++ b/src/webmachine_deps.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_error.erl
+++ b/src/webmachine_error.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/webmachine_error_handler.erl
+++ b/src/webmachine_error_handler.erl
@@ -7,7 +7,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_log.erl
+++ b/src/webmachine_log.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/webmachine_log_handler.erl
+++ b/src/webmachine_log_handler.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/webmachine_logger_watcher.erl
+++ b/src/webmachine_logger_watcher.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/webmachine_logger_watcher_sup.erl
+++ b/src/webmachine_logger_watcher_sup.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_multipart.erl
+++ b/src/webmachine_multipart.erl
@@ -8,7 +8,7 @@
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 
-%% http://www.apache.org/licenses/LICENSE-2.0
+%% https://www.apache.org/licenses/LICENSE-2.0
 
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_perf_log_handler.erl
+++ b/src/webmachine_perf_log_handler.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -7,7 +7,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -5,7 +5,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_sup.erl
+++ b/src/webmachine_sup.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -7,7 +7,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -5,7 +5,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/etag_test.erl
+++ b/test/etag_test.erl
@@ -6,7 +6,7 @@
 %%    you may not use this file except in compliance with the License.
 %%    You may obtain a copy of the License at
 %%
-%%        http://www.apache.org/licenses/LICENSE-2.0
+%%        https://www.apache.org/licenses/LICENSE-2.0
 %%
 %%    Unless required by applicable law or agreed to in writing, software
 %%    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 21 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).